### PR TITLE
Update MMM-MyPrayerTimes.js

### DIFF
--- a/MMM-MyPrayerTimes.js
+++ b/MMM-MyPrayerTimes.js
@@ -41,11 +41,6 @@ Module.register('MMM-MyPrayerTimes', {
 		// If you're trying to build your own module including translations, check out the documentation.
 		return false;
 	},
-			
-	// Override getHeader method.
- 	getHeader: function() {
- 		return this.config.header;
- 	},
 	
 	start: function() {
 		Log.info("Starting module: " + this.name);


### PR DESCRIPTION
Update for getHeader function. 
With new release 2.7.0 of MagicMirror, Header was not shown